### PR TITLE
Add the `inclusive` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgfplots"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A Rust library to generate publication-quality figures"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,14 @@ keywords = ["pgfplots", "plotting", "plot", "visualization", "latex"]
 categories = ["visualization"]
 documentation = "https://docs.rs/pgfplots"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+tectonic = { version = "0.9", optional = true }
+tempfile = { version = "3", optional = true }
+opener = { version = "0.5", optional = true }
+
+[features]
+inclusive = ["dep:tectonic", "dep:tempfile", "dep:opener"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -10,15 +10,11 @@ high-quality plots.
 
 ## Usage
 
-Users need to have `pdflatex` available in their system with the `pgfplots`
-package. In the unlikely scenario that you don't have this already, install
-any LaTeX distribution manually.
-
 Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-pgfplots = "0.1"
+pgfplots = { version = "0.2", features = ["inclusive"] }
 ```
 
 Plotting a quadratic function is as simple as:
@@ -32,14 +28,40 @@ plot.coordinates = (-100..100)
     .map(|i| (f64::from(i), f64::from(i*i)).into())
     .collect();
 
-let status = plot
-    .pdflatex_standalone("figure")
-    .expect("failed to run pdflatex");
+plot.show()?;
+```
 
-if status.success() {
-    // There is a `figure.pdf` in current working directory with our picture
-    // There are also `figure.log` and `figure.aux` that we can safely remove
-}
+## Features
+
+- Inclusive: Allow users to process the LaTeX code that generates figures
+without relying on any externally installed software, configuration, or
+resource files. This is achieved by including the
+[tectonic](https://crates.io/crates/tectonic) crate as a dependency.
+
+If you already have a LaTeX distribution installed in your system, it is
+recommended not to use this feature and process the LaTeX code directly; this
+will significantly reduce compilation and processing times. Plotting a quadratic
+function is still very simple:
+
+```rust
+use pgfplots::axis::plot::Plot2D;
+use std::process::{Command, Stdio};
+
+let mut plot = Plot2D::new();
+plot.coordinates = (-100..100)
+    .into_iter()
+    .map(|i| (f64::from(i), f64::from(i*i)).into())
+    .collect();
+
+let argument = plot.standalone_string().replace('\n', "").replace('\t', "");
+Command::new("pdflatex")
+    .stdout(Stdio::null())
+    .stderr(Stdio::null())
+    .arg("-interaction=batchmode")
+    .arg("-halt-on-error")
+    .arg("-jobname=figure")
+    .arg(argument)
+    .status();
 ```
 
 ## Want to contribute?

--- a/README.md
+++ b/README.md
@@ -38,31 +38,31 @@ without relying on any externally installed software, configuration, or
 resource files. This is achieved by including the
 [tectonic](https://crates.io/crates/tectonic) crate as a dependency.
 
-If you already have a LaTeX distribution installed in your system, it is
+	If you already have a LaTeX distribution installed in your system, it is
 recommended not to use this feature and process the LaTeX code directly; this
 will significantly reduce compilation and processing times. Plotting a quadratic
 function is still very simple:
 
-```rust
-use pgfplots::axis::plot::Plot2D;
-use std::process::{Command, Stdio};
+	```rust
+	use pgfplots::axis::plot::Plot2D;
+	use std::process::{Command, Stdio};
 
-let mut plot = Plot2D::new();
-plot.coordinates = (-100..100)
-    .into_iter()
-    .map(|i| (f64::from(i), f64::from(i*i)).into())
-    .collect();
+	let mut plot = Plot2D::new();
+	plot.coordinates = (-100..100)
+		.into_iter()
+		.map(|i| (f64::from(i), f64::from(i*i)).into())
+		.collect();
 
-let argument = plot.standalone_string().replace('\n', "").replace('\t', "");
-Command::new("pdflatex")
-    .stdout(Stdio::null())
-    .stderr(Stdio::null())
-    .arg("-interaction=batchmode")
-    .arg("-halt-on-error")
-    .arg("-jobname=figure")
-    .arg(argument)
-    .status();
-```
+	let argument = plot.standalone_string().replace('\n', "").replace('\t', "");
+	Command::new("pdflatex")
+		.stdout(Stdio::null())
+		.stderr(Stdio::null())
+		.arg("-interaction=batchmode")
+		.arg("-halt-on-error")
+		.arg("-jobname=figure")
+		.arg(argument)
+		.status();
+	```
 
 ## Want to contribute?
 

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -1,5 +1,5 @@
 use crate::axis::plot::Plot2D;
-use std::{fmt, process::ExitStatus};
+use std::fmt;
 
 // Only imported for documentation. If you notice that this is no longer the
 // case, please change it.
@@ -64,15 +64,6 @@ impl fmt::Display for AxisKey {
 /// axis.set_title("Picture of $\\gamma$ rays");
 /// axis.set_x_label("$x$~[m]");
 /// axis.set_y_label("$y$~[m]");
-///
-/// let status = axis
-///     .pdflatex_standalone("figure")
-///     .expect("failed to run pdflatex");
-///
-/// if status.success() {
-///     // There is a `figure.pdf` in current working directory with our picture
-///     // There are also `figure.log` and `figure.aux` that we can safely remove
-/// }
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct Axis {
@@ -182,35 +173,6 @@ impl Axis {
             }
         }
         self.keys.push(key);
-    }
-    /// Executes `pdflatex` with the given `-jobname` as a child process,
-    /// waiting for it to finish and collecting its status.
-    ///
-    /// If successful, this produces a `jobname.pdf` file with the [`Axis`]
-    /// as a standalone PDF. The [`Axis`] is wrapped in a default [`Picture`];
-    /// if you want to customize the picture environment, add the [`Axis`] to a
-    /// [`Picture`] manually.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use pgfplots::axis::Axis;
-    ///
-    /// let mut axis = Axis::new();
-    ///
-    /// let status = axis
-    ///     .pdflatex_standalone("figure")
-    ///     .expect("failed to execute pdflatex");
-    ///
-    /// if status.success() {
-    ///     // There is a `figure.pdf` file with our picture
-    ///     // There are also `figure.log` and `figure.aux` that we can safely remove
-    /// }
-    /// ```
-    pub fn pdflatex_standalone(&self, jobname: &str) -> std::io::Result<ExitStatus> {
-        let mut picture = Picture::new();
-        picture.axes.push(self.clone());
-        picture.pdflatex_standalone(jobname)
     }
 }
 

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -1,10 +1,5 @@
-use crate::axis::plot::Plot2D;
+use crate::{axis::plot::Plot2D, Picture};
 use std::fmt;
-
-// Only imported for documentation. If you notice that this is no longer the
-// case, please change it.
-#[allow(unused_imports)]
-use crate::Picture;
 
 /// Plot inside an [`Axis`] environment.
 pub mod plot;
@@ -173,6 +168,38 @@ impl Axis {
             }
         }
         self.keys.push(key);
+    }
+    /// Return a [`String`] with valid LaTeX code that generates a standalone
+    /// PDF with the axis in a default picture environment.
+    ///
+    /// # Note
+    ///
+    /// Passing this string directly to e.g. `pdflatex` will fail to generate a
+    /// PDF document. It is usually necessary to [`str::replace`] all the
+    /// occurrences of `\n` and `\t` with white space before sending this string
+    /// as an argument to a LaTeX compiler.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pgfplots::axis::Axis;
+    ///
+    /// let mut axis = Axis::new();
+    /// assert_eq!(
+    /// r#"\documentclass{standalone}
+    /// \usepackage{pgfplots}
+    /// \begin{document}
+    /// \begin{tikzpicture}
+    /// \begin{axis}
+    /// \end{axis}
+    /// \end{tikzpicture}
+    /// \end{document}"#,
+    /// axis.standalone_string());
+    /// ```
+    pub fn standalone_string(&self) -> String {
+        let mut picture = Picture::new();
+        picture.axes.push(self.clone());
+        picture.standalone_string()
     }
 }
 

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -1,6 +1,9 @@
 use crate::{axis::plot::Plot2D, Picture};
 use std::fmt;
 
+#[cfg(feature = "inclusive")]
+use crate::ShowPdfError;
+
 /// Plot inside an [`Axis`] environment.
 pub mod plot;
 
@@ -59,6 +62,9 @@ impl fmt::Display for AxisKey {
 /// axis.set_title("Picture of $\\gamma$ rays");
 /// axis.set_x_label("$x$~[m]");
 /// axis.set_y_label("$y$~[m]");
+///
+/// # #[cfg(feature = "inclusive")]
+/// axis.show();
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct Axis {
@@ -200,6 +206,24 @@ impl Axis {
         let mut picture = Picture::new();
         picture.axes.push(self.clone());
         picture.standalone_string()
+    }
+    /// Show the axis in a default [`Picture`] as a standalone PDF. This will
+    /// create a file in the location returned by [`std::env::temp_dir()`] and
+    /// open it with the default PDF viewer in your system.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use pgfplots::axis::Axis;
+    ///
+    /// let mut axis = Axis::new();
+    /// axis.show();
+    /// ```
+    #[cfg(feature = "inclusive")]
+    pub fn show(&self) -> Result<(), ShowPdfError> {
+        let mut picture = Picture::new();
+        picture.axes.push(self.clone());
+        picture.show()
     }
 }
 

--- a/src/axis/plot.rs
+++ b/src/axis/plot.rs
@@ -1,10 +1,5 @@
-use crate::axis::plot::coordinate::Coordinate2D;
+use crate::axis::{plot::coordinate::Coordinate2D, Axis};
 use std::fmt;
-
-// Only imported for documentation. If you notice that this is no longer the
-// case, please change it.
-#[allow(unused_imports)]
-use crate::axis::Axis;
 
 /// Coordinates inside a plot.
 pub mod coordinate;
@@ -141,6 +136,40 @@ impl Plot2D {
             }
         }
         self.keys.push(key);
+    }
+    /// Return a [`String`] with valid LaTeX code that generates a standalone
+    /// PDF with the plot in a default axis and picture environment.
+    ///
+    /// # Note
+    ///
+    /// Passing this string directly to e.g. `pdflatex` will fail to generate a
+    /// PDF document. It is usually necessary to [`str::replace`] all the
+    /// occurrences of `\n` and `\t` with white space before sending this string
+    /// as an argument to a LaTeX compiler.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pgfplots::axis::plot::Plot2D;
+    ///
+    /// let mut plot = Plot2D::new();
+    /// assert_eq!(
+    /// "\\documentclass{standalone}
+    /// \\usepackage{pgfplots}
+    /// \\begin{document}
+    /// \\begin{tikzpicture}
+    /// \\begin{axis}
+    /// \t\\addplot[] coordinates {
+    /// \t};
+    /// \\end{axis}
+    /// \\end{tikzpicture}
+    /// \\end{document}",
+    /// plot.standalone_string());
+    /// ```
+    pub fn standalone_string(&self) -> String {
+        let mut axis = Axis::new();
+        axis.plots.push(self.clone());
+        axis.standalone_string()
     }
 }
 

--- a/src/axis/plot.rs
+++ b/src/axis/plot.rs
@@ -1,6 +1,15 @@
 use crate::axis::{plot::coordinate::Coordinate2D, Axis};
 use std::fmt;
 
+#[cfg(feature = "inclusive")]
+use crate::ShowPdfError;
+
+// Only imported for documentation. If you notice that this is no longer the
+// case, please change it.
+#[cfg(feature = "inclusive")]
+#[allow(unused_imports)]
+use crate::Picture;
+
 /// Coordinates inside a plot.
 pub mod coordinate;
 
@@ -67,6 +76,9 @@ impl fmt::Display for PlotKey {
 ///     .into_iter()
 ///     .map(|i| (f64::from(i), f64::from(i*i)).into())
 ///     .collect();
+///
+/// # #[cfg(feature = "inclusive")]
+/// plot.show();
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct Plot2D {
@@ -170,6 +182,25 @@ impl Plot2D {
         let mut axis = Axis::new();
         axis.plots.push(self.clone());
         axis.standalone_string()
+    }
+    /// Show the plot in a default [`Axis`] and [`Picture`] as a standalone PDF.
+    /// This will create a file in the location returned by
+    /// [`std::env::temp_dir()`] and open it with the default PDF viewer in your
+    /// system.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use pgfplots::axis::plot::Plot2D;
+    ///
+    /// let mut plot = Plot2D::new();
+    /// plot.show();
+    /// ```
+    #[cfg(feature = "inclusive")]
+    pub fn show(&self) -> Result<(), ShowPdfError> {
+        let mut axis = Axis::new();
+        axis.plots.push(self.clone());
+        axis.show()
     }
 }
 

--- a/src/axis/plot.rs
+++ b/src/axis/plot.rs
@@ -1,5 +1,5 @@
 use crate::axis::plot::coordinate::Coordinate2D;
-use std::{fmt, process::ExitStatus};
+use std::fmt;
 
 // Only imported for documentation. If you notice that this is no longer the
 // case, please change it.
@@ -72,15 +72,6 @@ impl fmt::Display for PlotKey {
 ///     .into_iter()
 ///     .map(|i| (f64::from(i), f64::from(i*i)).into())
 ///     .collect();
-///
-/// let status = plot
-///     .pdflatex_standalone("figure")
-///     .expect("failed to run pdflatex");
-///
-/// if status.success() {
-///     // There is a `figure.pdf` in current working directory with our picture
-///     // There are also `figure.log` and `figure.aux` that we can safely remove
-/// }
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct Plot2D {
@@ -150,35 +141,6 @@ impl Plot2D {
             }
         }
         self.keys.push(key);
-    }
-    /// Executes `pdflatex` with the given `-jobname` as a child process,
-    /// waiting for it to finish and collecting its status.
-    ///
-    /// If successful, this produces a `jobname.pdf` file with the [`Plot2D`]
-    /// as a standalone PDF. The [`Plot2D`] is wrapped in a default [`Axis`];
-    /// if you want to customize the axis environment, add the [`Plot2D`] to an
-    /// [`Axis`] manually.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use pgfplots::axis::plot::Plot2D;
-    ///
-    /// let mut plot = Plot2D::new();
-    ///
-    /// let status = plot
-    ///     .pdflatex_standalone("figure")
-    ///     .expect("failed to execute pdflatex");
-    ///
-    /// if status.success() {
-    ///     // There is a `figure.pdf` file with our picture
-    ///     // There are also `figure.log` and `figure.aux` that we can safely remove
-    /// }
-    /// ```
-    pub fn pdflatex_standalone(&self, jobname: &str) -> std::io::Result<ExitStatus> {
-        let mut axis = Axis::new();
-        axis.plots.push(self.clone());
-        axis.pdflatex_standalone(jobname)
     }
 }
 

--- a/src/axis/plot/tests.rs
+++ b/src/axis/plot/tests.rs
@@ -249,6 +249,24 @@ fn plot_2d_add_key() {
 }
 
 #[test]
+fn plot_standalone_string() {
+    let plot = Plot2D::new();
+    assert_eq!(
+        "\\documentclass{standalone}
+\\usepackage{pgfplots}
+\\begin{document}
+\\begin{tikzpicture}
+\\begin{axis}
+\t\\addplot[] coordinates {
+\t};
+\\end{axis}
+\\end{tikzpicture}
+\\end{document}",
+        plot.standalone_string()
+    );
+}
+
+#[test]
 fn plot_2d_to_string() {
     let mut plot = Plot2D::new();
     assert_eq!(plot.to_string(), "\t\\addplot[] coordinates {\n\t};");

--- a/src/axis/tests.rs
+++ b/src/axis/tests.rs
@@ -160,6 +160,22 @@ fn axis_add_key() {
 }
 
 #[test]
+fn axis_standalone_string() {
+    let axis = Axis::new();
+    assert_eq!(
+        r#"\documentclass{standalone}
+\usepackage{pgfplots}
+\begin{document}
+\begin{tikzpicture}
+\begin{axis}
+\end{axis}
+\end{tikzpicture}
+\end{document}"#,
+        axis.standalone_string()
+    );
+}
+
+#[test]
 fn axis_to_string() {
     let mut axis = Axis::new();
     assert_eq!(axis.to_string(), "\\begin{axis}\n\\end{axis}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,9 @@
 //! A Rust library to generate publication-quality figures.
 //!
 //! This crate is a PGFPlots code generator, and provides utilities to create,
-//! customize, and compile high-quality plots. Users need to have the `pdflatex`
-//! LaTeX compiler available in their system with the `pgfplots` package.
+//! customize, and compile high-quality plots. The `inclusive` feature allows
+//! users to fully process figures without relying on any externally installed
+//! software.
 //!
 //! The library's API is designed to feel natural for LaTeX and PGFPlots users,
 //! but no previous experience is required to start generating

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@
 //!     .into_iter()
 //!     .map(|i| (f64::from(i), f64::from(i*i)).into())
 //!     .collect();
+//!
+//! # #[cfg(feature = "inclusive")]
+//! plot.show();
 //! ```
 //!
 //! It is possible to show multiple plots in the same axis environment by
@@ -39,8 +42,60 @@ use crate::axis::{
 use crate::axis::Axis;
 use std::fmt;
 
+#[cfg(feature = "inclusive")]
+use std::io::Write;
+
 /// Axis environment inside a [`Picture`].
 pub mod axis;
+
+/// The error type returned when showing a figure fails.
+#[cfg(feature = "inclusive")]
+#[derive(Clone, Copy, Debug)]
+pub enum ShowPdfError {
+    /// Compilation of LaTeX source failed internally
+    Compile,
+    /// Creating or writing to temporary file failed
+    Write,
+    /// Persisting the temporary file failed
+    Persist,
+    /// Opening the file failed
+    Open,
+}
+#[cfg(feature = "inclusive")]
+impl fmt::Display for ShowPdfError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            ShowPdfError::Compile => write!(f, "tectonic compilation error"),
+            ShowPdfError::Write => write!(f, "creating or writing to temporary file failed"),
+            ShowPdfError::Persist => write!(f, "persisting temporary file failed"),
+            ShowPdfError::Open => write!(f, "opening file error"),
+        }
+    }
+}
+#[cfg(feature = "inclusive")]
+impl From<tectonic::errors::Error> for ShowPdfError {
+    fn from(_: tectonic::errors::Error) -> Self {
+        Self::Compile
+    }
+}
+#[cfg(feature = "inclusive")]
+impl From<std::io::Error> for ShowPdfError {
+    fn from(_: std::io::Error) -> Self {
+        Self::Write
+    }
+}
+#[cfg(feature = "inclusive")]
+impl From<tempfile::PersistError> for ShowPdfError {
+    fn from(_: tempfile::PersistError) -> Self {
+        Self::Persist
+    }
+}
+#[cfg(feature = "inclusive")]
+impl From<opener::OpenError> for ShowPdfError {
+    fn from(_: opener::OpenError) -> Self {
+        Self::Open
+    }
+}
 
 /// Ti*k*Z options passed to the [`Picture`] environment.
 ///
@@ -169,6 +224,30 @@ impl Picture {
             + "\\begin{document}\n"
             + &self.to_string()
             + "\n\\end{document}"
+    }
+    /// Show the picture as a standalone PDF. This will create a file in the
+    /// location returned by [`std::env::temp_dir()`] and open it with the
+    /// default PDF viewer in your system.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use pgfplots::Picture;
+    ///
+    /// let mut picture = Picture::new();
+    /// picture.show();
+    /// ```
+    #[cfg(feature = "inclusive")]
+    pub fn show(&self) -> Result<(), ShowPdfError> {
+        let pdf_data = tectonic::latex_to_pdf(self.standalone_string())?;
+
+        let mut file = tempfile::NamedTempFile::new()?;
+        file.write_all(&pdf_data)?;
+        let (_file, path) = file.keep()?;
+
+        opener::open(&path)?;
+
+        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,38 @@ impl Picture {
         }
         self.keys.push(key);
     }
+    /// Return a [`String`] with valid LaTeX code that generates a standalone
+    /// PDF with the picture environment.
+    ///
+    /// # Note
+    ///
+    /// Passing this string directly to e.g. `pdflatex` will fail to generate a
+    /// PDF document. It is usually necessary to [`str::replace`] all the
+    /// occurrences of `\n` and `\t` with white space before sending this string
+    /// as an argument to a LaTeX compiler.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pgfplots::Picture;
+    ///
+    /// let mut picture = Picture::new();
+    /// assert_eq!(
+    /// r#"\documentclass{standalone}
+    /// \usepackage{pgfplots}
+    /// \begin{document}
+    /// \begin{tikzpicture}
+    /// \end{tikzpicture}
+    /// \end{document}"#,
+    /// picture.standalone_string());
+    /// ```
+    pub fn standalone_string(&self) -> String {
+        String::from("\\documentclass{standalone}\n")
+            + "\\usepackage{pgfplots}\n"
+            + "\\begin{document}\n"
+            + &self.to_string()
+            + "\n\\end{document}"
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 //! A Rust library to generate publication-quality figures.
 //!
 //! This crate is a PGFPlots code generator, and provides utilities to create,
@@ -21,15 +22,6 @@
 //!     .into_iter()
 //!     .map(|i| (f64::from(i), f64::from(i*i)).into())
 //!     .collect();
-//!
-//! let status = plot
-//!     .pdflatex_standalone("figure")
-//!     .expect("failed to run pdflatex");
-//!
-//! if status.success() {
-//!     // There is a `figure.pdf` in current working directory with our picture
-//!     // There are also `figure.log` and `figure.aux` that we can safely remove
-//! }
 //! ```
 //!
 //! It is possible to show multiple plots in the same axis environment by
@@ -46,7 +38,6 @@ use crate::axis::{
 
 use crate::axis::Axis;
 use std::fmt;
-use std::process::{Command, ExitStatus, Stdio};
 
 /// Axis environment inside a [`Picture`].
 pub mod axis;
@@ -146,45 +137,6 @@ impl Picture {
             // Axis::add_key and Plot2D::add_key
         }
         self.keys.push(key);
-    }
-    /// Executes `pdflatex` with the given `-jobname` as a child process,
-    /// waiting for it to finish and collecting its status.
-    ///
-    /// If successful, this produces a `jobname.pdf` file with the [`Picture`]
-    /// as a standalone PDF.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use pgfplots::Picture;
-    ///
-    /// let mut picture = Picture::new();
-    ///
-    /// let status = picture
-    ///     .pdflatex_standalone("figure")
-    ///     .expect("failed to execute pdflatex");
-    ///
-    /// if status.success() {
-    ///     // There is a `figure.pdf` file with our picture
-    ///     // There are also `figure.log` and `figure.aux` that we can safely remove
-    /// }
-    /// ```
-    pub fn pdflatex_standalone(&self, jobname: &str) -> std::io::Result<ExitStatus> {
-        let argument =
-            (String::from("\\documentclass{standalone}\\usepackage{pgfplots}\\begin{document}")
-                + &self.to_string()
-                + "\\end{document}")
-                .replace('\n', "")
-                .replace('\t', "");
-
-        Command::new("pdflatex")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .arg("-interaction=batchmode")
-            .arg("-halt-on-error")
-            .arg(String::from("-jobname=") + jobname)
-            .arg(argument)
-            .status()
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -46,6 +46,20 @@ fn picture_add_key() {
 }
 
 #[test]
+fn picture_standalone_string() {
+    let picture = Picture::new();
+    assert_eq!(
+        r#"\documentclass{standalone}
+\usepackage{pgfplots}
+\begin{document}
+\begin{tikzpicture}
+\end{tikzpicture}
+\end{document}"#,
+        picture.standalone_string()
+    );
+}
+
+#[test]
 fn picture_to_string() {
     let mut picture = Picture::new();
     assert_eq!(


### PR DESCRIPTION
Thanks to the `tectonic` crate, this will allow users to generate figures without having a LaTeX distribution installed in their system. Tectonic is a big project, orders of magnitude more complex than this PGFPlots code generator. For this reason, the `tectonic` crate is "hidden" behind the `inclusive` feature for people that want to view plots directly. For people that already have a LaTeX distribution, it is recommended to compile the LaTeX code directly (it reduces significantly compilation and processing times).