### PR TITLE
Fix issue #5. Add Type2D::XBar and Type2D::YBar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgfplots"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "A Rust library to generate publication-quality figures"

--- a/examples/rectangle_integration.rs
+++ b/examples/rectangle_integration.rs
@@ -1,5 +1,5 @@
 use pgfplots::axis::{
-    plot::{Plot2D, PlotKey},
+    plot::{Plot2D, PlotKey, Type2D},
     Axis, AxisKey,
 };
 
@@ -19,7 +19,10 @@ fn main() {
         .map(|i| (f64::from(i), f64::from(i * i)).into())
         .collect();
     // Currently have to "guess" the bar width. Still pending the \compat key
-    rectangles.add_key(PlotKey::Custom(String::from("ybar, bar width=19.5")));
+    rectangles.add_key(PlotKey::Type2D(Type2D::YBar {
+        bar_width: 19.5,
+        bar_shift: 0.0,
+    }));
     rectangles.add_key(PlotKey::Custom(String::from("fill=gray!20")));
     rectangles.add_key(PlotKey::Custom(String::from("draw opacity=0.5")));
 

--- a/src/axis/plot.rs
+++ b/src/axis/plot.rs
@@ -6,7 +6,6 @@ use crate::ShowPdfError;
 
 // Only imported for documentation. If you notice that this is no longer the
 // case, please change it.
-#[cfg(feature = "inclusive")]
 #[allow(unused_imports)]
 use crate::Picture;
 
@@ -229,6 +228,19 @@ pub enum Type2D {
     JumpRight,
     /// Variant of [`Type2D::ConstMid`] which does not draw vertical lines.
     JumpMid,
+    /// Draw horizontal bars between the *y = 0* line and each coordinate. The
+    /// `bar_width` field controls the width of the horizontal bars, and
+    /// `bar_shift` controls the vertical shift. Unless you are plotting
+    /// multiple bars in the same [`Axis`], you most likely want `bar_shift: 0`.
+    ///
+    /// # Note
+    ///
+    /// By default, `bar_width` and `bar_shift` are assumed to be in `pt` units.
+    /// If you want them to be interpreted as axis units (this is most likely
+    /// what you want), you need to add the plot to an [`Axis`], add the
+    /// [`Axis`] to a [`Picture`], and set `compat=1.7` or higher on the
+    /// [`Picture`].
+    XBar { bar_width: f64, bar_shift: f64 },
     /// Similar to [`Type2D::XBar`] except that it draws a single horizontal
     /// lines instead of rectangles.
     XComb,
@@ -249,6 +261,10 @@ impl fmt::Display for Type2D {
             Type2D::JumpLeft => write!(f, "jump mark left"),
             Type2D::JumpRight => write!(f, "jump mark right"),
             Type2D::JumpMid => write!(f, "jump mark mid"),
+            Type2D::XBar {
+                bar_width,
+                bar_shift,
+            } => write!(f, "xbar, bar width={bar_width}, bar shift={bar_shift}"),
             Type2D::XComb => write!(f, "xcomb"),
             Type2D::YComb => write!(f, "ycomb"),
             Type2D::OnlyMarks => write!(f, "only marks"),

--- a/src/axis/plot.rs
+++ b/src/axis/plot.rs
@@ -231,7 +231,8 @@ pub enum Type2D {
     /// Draw horizontal bars between the *y = 0* line and each coordinate. The
     /// `bar_width` field controls the width of the horizontal bars, and
     /// `bar_shift` controls the vertical shift. Unless you are plotting
-    /// multiple bars in the same [`Axis`], you most likely want `bar_shift: 0`.
+    /// multiple bars in the same [`Axis`], you most likely want
+    /// `bar_shift: 0.0`.
     ///
     /// # Note
     ///
@@ -241,6 +242,20 @@ pub enum Type2D {
     /// [`Axis`] to a [`Picture`], and set `compat=1.7` or higher on the
     /// [`Picture`].
     XBar { bar_width: f64, bar_shift: f64 },
+    /// Draw vertical bars between the *x = 0* line and each coordinate. The
+    /// `bar_width` field controls the width of the vertical bars, and
+    /// `bar_shift` controls the horizontal shift. Unless you are plotting
+    /// multiple bars in the same [`Axis`], you most likely want
+    /// `bar_shift: 0.0`.
+    ///
+    /// # Note
+    ///
+    /// By default, `bar_width` and `bar_shift` are assumed to be in `pt` units.
+    /// If you want them to be interpreted as axis units (this is most likely
+    /// what you want), you need to add the plot to an [`Axis`], add the
+    /// [`Axis`] to a [`Picture`], and set `compat=1.7` or higher on the
+    /// [`Picture`].
+    YBar { bar_width: f64, bar_shift: f64 },
     /// Similar to [`Type2D::XBar`] except that it draws a single horizontal
     /// lines instead of rectangles.
     XComb,
@@ -265,6 +280,10 @@ impl fmt::Display for Type2D {
                 bar_width,
                 bar_shift,
             } => write!(f, "xbar, bar width={bar_width}, bar shift={bar_shift}"),
+            Type2D::YBar {
+                bar_width,
+                bar_shift,
+            } => write!(f, "ybar, bar width={bar_width}, bar shift={bar_shift}"),
             Type2D::XComb => write!(f, "xcomb"),
             Type2D::YComb => write!(f, "ycomb"),
             Type2D::OnlyMarks => write!(f, "only marks"),

--- a/src/axis/plot.rs
+++ b/src/axis/plot.rs
@@ -210,10 +210,10 @@ impl Plot2D {
 pub enum Type2D {
     /// Coordinates are simply connected by straight lines.
     SharpPlot,
-    /// Interpolate smoothly between successive points. The internal [`f64`]
-    /// corresponds to the tension; recommended initial value is
-    /// `Type2D::Smooth(0.55)`. A higher value results in more "round" curves.
-    Smooth(f64),
+    /// Interpolate smoothly between successive points. The `tension` controls
+    /// how "smooth" a plot is; recommended initial value is `Type2D::Smooth{
+    /// tension: 0.55 }`. A higher value results in more "round" curves.
+    Smooth { tension: f64 },
     /// Coordinates are connected with horizontal and vertical lines. Marks are
     /// placed to the left of each horizontal line.
     ConstLeft,
@@ -242,7 +242,7 @@ impl fmt::Display for Type2D {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Type2D::SharpPlot => write!(f, "sharp plot"),
-            Type2D::Smooth(tension) => write!(f, "smooth, tension={tension}"),
+            Type2D::Smooth { tension } => write!(f, "smooth, tension={tension}"),
             Type2D::ConstLeft => write!(f, "const plot mark left"),
             Type2D::ConstRight => write!(f, "const plot mark right"),
             Type2D::ConstMid => write!(f, "const plot mark mid"),

--- a/src/axis/plot/tests.rs
+++ b/src/axis/plot/tests.rs
@@ -20,6 +20,36 @@ fn error_character_to_string() {
     );
 }
 
+// This test is here only to let us know if we added an enum variant
+// but we forgot to add unit tests for it
+//
+// If this fails, it is because you added a new variant.
+// Please do the following:
+// 1) Add a unit test for the new variant you added (see examples below).
+// 2) AFTER doing (1), add the new variant to the match.
+#[test]
+fn plot_type2d_tested() {
+    let type_2d = Type2D::OnlyMarks;
+    match type_2d {
+        Type2D::SharpPlot => (),
+        Type2D::Smooth { tension: _ } => (),
+        Type2D::ConstLeft => (),
+        Type2D::ConstRight => (),
+        Type2D::ConstMid => (),
+        Type2D::JumpLeft => (),
+        Type2D::JumpRight => (),
+        Type2D::JumpMid => (),
+        Type2D::XBar {
+            bar_width: _,
+            bar_shift: _,
+        } => (),
+        Type2D::XComb => (),
+        Type2D::YComb => (),
+        Type2D::OnlyMarks => (),
+    }
+    assert!(true);
+}
+
 #[test]
 fn type_2d_to_string() {
     assert_eq!(Type2D::SharpPlot.to_string(), String::from("sharp plot"));
@@ -45,6 +75,22 @@ fn type_2d_to_string() {
         String::from("jump mark right")
     );
     assert_eq!(Type2D::JumpMid.to_string(), String::from("jump mark mid"));
+    assert_eq!(
+        Type2D::XBar {
+            bar_width: 0.5,
+            bar_shift: 1.0
+        }
+        .to_string(),
+        String::from("xbar, bar width=0.5, bar shift=1")
+    );
+    assert_eq!(
+        Type2D::XBar {
+            bar_shift: 1.0,
+            bar_width: 0.5
+        }
+        .to_string(),
+        String::from("xbar, bar width=0.5, bar shift=1")
+    );
     assert_eq!(Type2D::XComb.to_string(), String::from("xcomb"));
     assert_eq!(Type2D::YComb.to_string(), String::from("ycomb"));
     assert_eq!(Type2D::OnlyMarks.to_string(), String::from("only marks"));

--- a/src/axis/plot/tests.rs
+++ b/src/axis/plot/tests.rs
@@ -24,7 +24,7 @@ fn error_character_to_string() {
 fn type_2d_to_string() {
     assert_eq!(Type2D::SharpPlot.to_string(), String::from("sharp plot"));
     assert_eq!(
-        Type2D::Smooth(0.55).to_string(),
+        Type2D::Smooth { tension: 0.55 }.to_string(),
         String::from("smooth, tension=0.55")
     );
     assert_eq!(

--- a/src/axis/plot/tests.rs
+++ b/src/axis/plot/tests.rs
@@ -43,6 +43,10 @@ fn plot_type2d_tested() {
             bar_width: _,
             bar_shift: _,
         } => (),
+        Type2D::YBar {
+            bar_width: _,
+            bar_shift: _,
+        } => (),
         Type2D::XComb => (),
         Type2D::YComb => (),
         Type2D::OnlyMarks => (),
@@ -90,6 +94,22 @@ fn type_2d_to_string() {
         }
         .to_string(),
         String::from("xbar, bar width=0.5, bar shift=1")
+    );
+    assert_eq!(
+        Type2D::YBar {
+            bar_width: 0.5,
+            bar_shift: 1.0
+        }
+        .to_string(),
+        String::from("ybar, bar width=0.5, bar shift=1")
+    );
+    assert_eq!(
+        Type2D::YBar {
+            bar_shift: 1.0,
+            bar_width: 0.5
+        }
+        .to_string(),
+        String::from("ybar, bar width=0.5, bar shift=1")
     );
     assert_eq!(Type2D::XComb.to_string(), String::from("xcomb"));
     assert_eq!(Type2D::YComb.to_string(), String::from("ycomb"));


### PR DESCRIPTION
Add support for horizontal and vertical bar plots. This is done through the new `Type2D::XBar` and `Type2D::YBar` variants.

This PR breaks the old `Type2D::Smooth(f64)` and changes it to `Type2D::Smooth { tension: f64 }`. This keeps consistency with e.g. `XBar` and `YBar`, and should be the way to define new variants in the future. It is just much more clear to have the inner required data named rather than just a simple `f64`.

Something important to keep in mind (also noted in the documentation) is that `bar_width` and `bar_shift` in the `Type2D::XBar` and `Type2D::YBar` assume by default units of `pt` (Latex's pgfplots fault). So it is a priority to fix issue #12. This will make it much more easy to work with bar plots in units of the axis (with `compat=1.7` or higher).

Usage of the new bar plots can be seen in `examples/rectangular_integration.rs`.
