### PR TITLE
Fix issue #18.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgfplots"
-version = "0.3.1"
+version = "0.4.0" # Remember to also change this in the README.md
 edition = "2021"
 license = "MIT"
 description = "A Rust library to generate publication-quality figures"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-pgfplots = { version = "0.3", features = ["inclusive"] }
+pgfplots = { version = "0.4", features = ["inclusive"] }
 ```
 
 Plotting a quadratic function is as simple as:

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -120,8 +120,8 @@ impl Axis {
     /// let mut axis = Axis::new();
     /// axis.set_title("My plot: $y = x^2$");
     /// ```
-    pub fn set_title(&mut self, title: &str) {
-        self.add_key(AxisKey::Title(String::from(title)));
+    pub fn set_title<S: Into<String>>(&mut self, title: S) {
+        self.add_key(AxisKey::Title(title.into()));
     }
     /// Set the label of the *x* axis. This can be valid LaTeX e.g. inline math.
     ///
@@ -133,8 +133,8 @@ impl Axis {
     /// let mut axis = Axis::new();
     /// axis.set_x_label("$x$~[m]");
     /// ```
-    pub fn set_x_label(&mut self, label: &str) {
-        self.add_key(AxisKey::XLabel(String::from(label)));
+    pub fn set_x_label<S: Into<String>>(&mut self, label: S) {
+        self.add_key(AxisKey::XLabel(label.into()));
     }
     /// Set the label of the *y* axis. This can be valid LaTeX e.g. inline math.
     ///
@@ -146,8 +146,8 @@ impl Axis {
     /// let mut axis = Axis::new();
     /// axis.set_y_label("$y$~[m]");
     /// ```
-    pub fn set_y_label(&mut self, label: &str) {
-        self.add_key(AxisKey::YLabel(String::from(label)));
+    pub fn set_y_label<S: Into<String>>(&mut self, label: S) {
+        self.add_key(AxisKey::YLabel(label.into()));
     }
     /// Add a key to control the appearance of the axis. This will overwrite
     /// any previous mutually exclusive key.


### PR DESCRIPTION
This introduces a "breaking" change, and allows `axis::set_title`, `axis::set_x_label`, and `axis::set_y_label` to accept a generic argument that implements `Into<String>` rather than a `&str`. I believe that this makes the intention more clear, and that these will still cause a `String` to be allocated internally. Most code should still compile exactly the same, and whatever code doesn't is trivially fixable with type annotations.