### PR TITLE
Added pdf extension to temporary file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ impl Picture {
     pub fn show(&self) -> Result<(), ShowPdfError> {
         let pdf_data = tectonic::latex_to_pdf(self.standalone_string())?;
 
-        let mut file = tempfile::NamedTempFile::new()?;
+        let mut file = tempfile::Builder::new().suffix(".pdf").tempfile()?;
         file.write_all(&pdf_data)?;
         let (_file, path) = file.keep()?;
 


### PR DESCRIPTION
By adding the `.pdf` extension to the temporary file the file opener correctly detects the program to open the PDF with on MacOS, without it it doesn't.