### PR TITLE
Improve error handling and tectonic dependance to visualize a plot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/DJDuque/pgfplots"
 keywords = ["pgfplots", "plotting", "plot", "visualization", "latex"]
 categories = ["visualization"]
 documentation = "https://docs.rs/pgfplots"
+exclude = ["examples/*.png"]
 
 [dependencies]
 opener = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgfplots"
-version = "0.4.1" # Remember to also change this in the README.md
+version = "0.5.0" # Remember to also change this in the README.md
 edition = "2021"
 license = "MIT"
 description = "A Rust library to generate publication-quality figures"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://docs.rs/pgfplots"
 
 [dependencies]
 opener = "0.5"
+rand = "0.8"
 tectonic = { version = "0.12", optional = true }
 tempfile = "3"
 thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ tectonic = { version = "0.12", optional = true }
 tempfile = "3"
 thiserror = "1"
 
-[features]
-inclusive = ["dep:tectonic"]
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,13 @@ categories = ["visualization"]
 documentation = "https://docs.rs/pgfplots"
 
 [dependencies]
+opener = "0.5"
 tectonic = { version = "0.12", optional = true }
-tempfile = { version = "3", optional = true }
-opener = { version = "0.5", optional = true }
+tempfile = "3"
+thiserror = "1"
 
 [features]
-inclusive = ["dep:tectonic", "dep:tempfile", "dep:opener"]
+inclusive = ["dep:tectonic"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-pgfplots = { version = "0.4", features = ["inclusive"] }
+pgfplots = "0.4"
 ```
 
 Plotting a quadratic function is as simple as:
 
 ```rust
-use pgfplots::axis::plot::Plot2D;
+use pgfplots::{axis::plot::Plot2D, Engine, Picture};
 
 let mut plot = Plot2D::new();
 plot.coordinates = (-100..100)
@@ -27,7 +27,7 @@ plot.coordinates = (-100..100)
     .map(|i| (f64::from(i), f64::from(i*i)).into())
     .collect();
 
-plot.show()?;
+Picture::from(plot).show_pdf(Engine::PdfLatex)?;
 ```
 
 ## [Examples](https://github.com/DJDuque/pgfplots/tree/main/examples)
@@ -42,37 +42,10 @@ A more extensive list of examples and their source code is available in the
 
 ## Features
 
-- Inclusive: Allow users to process the LaTeX code that generates figures
+- Tectonic: Allow users to process the LaTeX code that generates figures
 without relying on any externally installed software, configuration, or
 resource files. This is achieved by including the
 [tectonic](https://crates.io/crates/tectonic) crate as a dependency.
-
-	If you already have a LaTeX distribution installed in your system, it is
-recommended to process the LaTeX code directly. The `tectonic` crate pulls in a
-lot of dependencies, which significantly increase compilation and processing
- times. Plotting a quadratic function is still very simple:
-
-	```rust
-	use pgfplots::axis::plot::Plot2D;
-	use std::process::{Command, Stdio};
-
-	let mut plot = Plot2D::new();
-	plot.coordinates = (-100..100)
-		.into_iter()
-		.map(|i| (f64::from(i), f64::from(i*i)).into())
-		.collect();
-
-	let argument = plot.standalone_string().replace('\n', "").replace('\t', "");
-	Command::new("pdflatex")
-		.stdout(Stdio::null())
-		.stderr(Stdio::null())
-		.arg("-interaction=batchmode")
-		.arg("-halt-on-error")
-		.arg("-jobname=figure")
-		.arg(argument)
-		.status()
-		.expect("Error: unable to run pdflatex");
-	```
 
 ## Want to contribute?
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-pgfplots = "0.4"
+pgfplots = "0.5"
 ```
 
 Plotting a quadratic function is as simple as:
@@ -46,16 +46,3 @@ A more extensive list of examples and their source code is available in the
 without relying on any externally installed software, configuration, or
 resource files. This is achieved by including the
 [tectonic](https://crates.io/crates/tectonic) crate as a dependency.
-
-## Want to contribute?
-
-There are multiple ways to contribute:
-- Install and test PGFPlots. If it doesn't work as expected please [open an
-  issue](https://github.com/DJDuque/pgfplots/issues/new).
-- Comment/propose a fix on some of the current [open 
-issues](https://github.com/DJDuque/pgfplots/issues).
-- Read through the [documentation](https://docs.rs/pgfplots). If there is 
-  something confusing, or you have a suggestion for something that could be 
-  improved, please let the maintainer(s) know.
-- Help evaluate [open pull requests](https://github.com/DJDuque/pgfplots/pulls),
-  by testing locally and reviewing what is proposed.

--- a/examples/fitted_line.rs
+++ b/examples/fitted_line.rs
@@ -1,6 +1,6 @@
-use pgfplots::axis::{
-    plot::{ErrorCharacter, ErrorDirection, Plot2D, PlotKey, Type2D},
-    Axis, AxisKey,
+use pgfplots::{
+    axis::{plot::*, *},
+    Engine, Picture,
 };
 use std::f64::consts::PI;
 
@@ -47,6 +47,8 @@ fn main() {
     axis.add_key(AxisKey::Custom(String::from("legend entries={fit,data}")));
     axis.add_key(AxisKey::Custom(String::from("legend pos=north west")));
 
-    #[cfg(feature = "inclusive")]
-    axis.show().unwrap();
+    #[cfg(feature = "tectonic")]
+    Picture::from(axis).show_pdf(Engine::Tectonic).unwrap();
+    #[cfg(not(feature = "tectonic"))]
+    Picture::from(axis).show_pdf(Engine::PdfLatex).unwrap();
 }

--- a/examples/rectangle_integration.rs
+++ b/examples/rectangle_integration.rs
@@ -1,6 +1,6 @@
-use pgfplots::axis::{
-    plot::{Plot2D, PlotKey, Type2D},
-    Axis, AxisKey,
+use pgfplots::{
+    axis::{plot::*, *},
+    Engine, Picture,
 };
 
 fn main() {
@@ -18,7 +18,8 @@ fn main() {
         .step_by(10)
         .map(|i| (f64::from(i), f64::from(i * i)).into())
         .collect();
-    // Currently have to "guess" the bar width. Still pending the \compat key
+    // Currently have to "guess" the bar width in pt units
+    // Still pending the \compat key
     rectangles.add_key(PlotKey::Type2D(Type2D::YBar {
         bar_width: 19.5,
         bar_shift: 0.0,
@@ -26,6 +27,7 @@ fn main() {
     rectangles.add_key(PlotKey::Custom(String::from("fill=gray!20")));
     rectangles.add_key(PlotKey::Custom(String::from("draw opacity=0.5")));
 
+    // Customise axis environment
     let mut axis = Axis::new();
     axis.set_title("Rectangle Integration");
     axis.set_x_label("$x$");
@@ -36,6 +38,8 @@ fn main() {
     axis.add_key(AxisKey::Custom(String::from("xlabel near ticks")));
     axis.add_key(AxisKey::Custom(String::from("ylabel near ticks")));
 
-    #[cfg(feature = "inclusive")]
-    axis.show().unwrap();
+    #[cfg(feature = "tectonic")]
+    Picture::from(axis).show_pdf(Engine::Tectonic).unwrap();
+    #[cfg(not(feature = "tectonic"))]
+    Picture::from(axis).show_pdf(Engine::PdfLatex).unwrap();
 }

--- a/examples/snowflake.rs
+++ b/examples/snowflake.rs
@@ -1,6 +1,6 @@
-use pgfplots::axis::{
-    plot::{Plot2D, PlotKey},
-    Axis, AxisKey,
+use pgfplots::{
+    axis::{plot::*, *},
+    Engine, Picture,
 };
 
 fn main() {
@@ -17,17 +17,20 @@ fn main() {
     };
     vertices.push(vertices[0]);
 
+    // Set snowflake
     let mut plot = Plot2D::new();
     plot.coordinates = vertices.into_iter().map(|v| v.into()).collect();
     plot.add_key(PlotKey::Custom(String::from("fill=gray!20")));
 
-    let mut axis = Axis::new();
+    // Customise axis environment
+    let mut axis = Axis::from(plot);
     axis.set_title("Kloch Snowflake");
-    axis.plots.push(plot);
     axis.add_key(AxisKey::Custom(String::from("hide axis")));
 
-    #[cfg(feature = "inclusive")]
-    axis.show().unwrap();
+    #[cfg(feature = "tectonic")]
+    Picture::from(axis).show_pdf(Engine::Tectonic).unwrap();
+    #[cfg(not(feature = "tectonic"))]
+    Picture::from(axis).show_pdf(Engine::PdfLatex).unwrap();
 }
 
 // Stolen from plotters crate example

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -65,7 +65,7 @@ impl fmt::Display for AxisKey {
 /// axis.set_x_label("$x$~[m]");
 /// axis.set_y_label("$y$~[m]");
 ///
-/// # #[cfg(feature = "inclusive")]
+/// # #[cfg(feature = "tectonic")]
 /// axis.show();
 /// ```
 #[derive(Clone, Debug, Default)]

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -98,6 +98,14 @@ impl fmt::Display for Axis {
     }
 }
 
+impl From<Plot2D> for Axis {
+    fn from(plot: Plot2D) -> Self {
+        Axis {
+            keys: Vec::new(),
+            plots: vec![plot],
+        }
+    }
+}
 impl Axis {
     /// Creates a new, empty axis environment.
     ///

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -58,15 +58,18 @@ impl fmt::Display for AxisKey {
 /// # Examples
 ///
 /// ```no_run
-/// use pgfplots::axis::Axis;
+/// # use pgfplots::ShowPdfError;
+/// # fn main() -> Result<(), ShowPdfError> {
+/// use pgfplots::{axis::Axis, Engine, Picture};
 ///
 /// let mut axis = Axis::new();
 /// axis.set_title("Picture of $\\gamma$ rays");
 /// axis.set_x_label("$x$~[m]");
 /// axis.set_y_label("$y$~[m]");
 ///
-/// # #[cfg(feature = "tectonic")]
-/// axis.show();
+/// Picture::from(axis).show_pdf(Engine::PdfLatex)?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct Axis {
@@ -114,7 +117,7 @@ impl Axis {
     /// ```
     /// use pgfplots::axis::Axis;
     ///
-    /// let mut axis = Axis::new();
+    /// let axis = Axis::new();
     /// ```
     pub fn new() -> Self {
         Default::default()

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -1,6 +1,11 @@
 use crate::axis::plot::Plot2D;
 use std::fmt;
 
+// Only imported for documentation. If you notice that this is no longer the
+// case, please change it.
+#[allow(unused_imports)]
+use crate::Picture;
+
 /// Plot inside an [`Axis`] environment.
 pub mod plot;
 

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -1,8 +1,5 @@
-use crate::{axis::plot::Plot2D, Picture};
+use crate::axis::plot::Plot2D;
 use std::fmt;
-
-#[cfg(feature = "inclusive")]
-use crate::ShowPdfError;
 
 /// Plot inside an [`Axis`] environment.
 pub mod plot;
@@ -174,56 +171,6 @@ impl Axis {
             }
         }
         self.keys.push(key);
-    }
-    /// Return a [`String`] with valid LaTeX code that generates a standalone
-    /// PDF with the axis in a default picture environment.
-    ///
-    /// # Note
-    ///
-    /// Passing this string directly to e.g. `pdflatex` will fail to generate a
-    /// PDF document. It is usually necessary to [`str::replace`] all the
-    /// occurrences of `\n` and `\t` with white space before sending this string
-    /// as an argument to a LaTeX compiler.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use pgfplots::axis::Axis;
-    ///
-    /// let mut axis = Axis::new();
-    /// assert_eq!(
-    /// r#"\documentclass{standalone}
-    /// \usepackage{pgfplots}
-    /// \begin{document}
-    /// \begin{tikzpicture}
-    /// \begin{axis}
-    /// \end{axis}
-    /// \end{tikzpicture}
-    /// \end{document}"#,
-    /// axis.standalone_string());
-    /// ```
-    pub fn standalone_string(&self) -> String {
-        let mut picture = Picture::new();
-        picture.axes.push(self.clone());
-        picture.standalone_string()
-    }
-    /// Show the axis in a default [`Picture`] as a standalone PDF. This will
-    /// create a file in the location returned by [`std::env::temp_dir()`] and
-    /// open it with the default PDF viewer in your system.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use pgfplots::axis::Axis;
-    ///
-    /// let mut axis = Axis::new();
-    /// axis.show();
-    /// ```
-    #[cfg(feature = "inclusive")]
-    pub fn show(&self) -> Result<(), ShowPdfError> {
-        let mut picture = Picture::new();
-        picture.axes.push(self.clone());
-        picture.show()
     }
 }
 

--- a/src/axis/plot.rs
+++ b/src/axis/plot.rs
@@ -1,8 +1,5 @@
-use crate::axis::{plot::coordinate::Coordinate2D, Axis};
+use crate::axis::plot::coordinate::Coordinate2D;
 use std::fmt;
-
-#[cfg(feature = "inclusive")]
-use crate::ShowPdfError;
 
 // Only imported for documentation. If you notice that this is no longer the
 // case, please change it.
@@ -147,59 +144,6 @@ impl Plot2D {
             }
         }
         self.keys.push(key);
-    }
-    /// Return a [`String`] with valid LaTeX code that generates a standalone
-    /// PDF with the plot in a default axis and picture environment.
-    ///
-    /// # Note
-    ///
-    /// Passing this string directly to e.g. `pdflatex` will fail to generate a
-    /// PDF document. It is usually necessary to [`str::replace`] all the
-    /// occurrences of `\n` and `\t` with white space before sending this string
-    /// as an argument to a LaTeX compiler.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use pgfplots::axis::plot::Plot2D;
-    ///
-    /// let mut plot = Plot2D::new();
-    /// assert_eq!(
-    /// "\\documentclass{standalone}
-    /// \\usepackage{pgfplots}
-    /// \\begin{document}
-    /// \\begin{tikzpicture}
-    /// \\begin{axis}
-    /// \t\\addplot[] coordinates {
-    /// \t};
-    /// \\end{axis}
-    /// \\end{tikzpicture}
-    /// \\end{document}",
-    /// plot.standalone_string());
-    /// ```
-    pub fn standalone_string(&self) -> String {
-        let mut axis = Axis::new();
-        axis.plots.push(self.clone());
-        axis.standalone_string()
-    }
-    /// Show the plot in a default [`Axis`] and [`Picture`] as a standalone PDF.
-    /// This will create a file in the location returned by
-    /// [`std::env::temp_dir()`] and open it with the default PDF viewer in your
-    /// system.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use pgfplots::axis::plot::Plot2D;
-    ///
-    /// let mut plot = Plot2D::new();
-    /// plot.show();
-    /// ```
-    #[cfg(feature = "inclusive")]
-    pub fn show(&self) -> Result<(), ShowPdfError> {
-        let mut axis = Axis::new();
-        axis.plots.push(self.clone());
-        axis.show()
     }
 }
 

--- a/src/axis/plot.rs
+++ b/src/axis/plot.rs
@@ -73,7 +73,7 @@ impl fmt::Display for PlotKey {
 ///     .map(|i| (f64::from(i), f64::from(i*i)).into())
 ///     .collect();
 ///
-/// # #[cfg(feature = "inclusive")]
+/// # #[cfg(feature = "tectonic")]
 /// plot.show();
 /// ```
 #[derive(Clone, Debug, Default)]

--- a/src/axis/plot.rs
+++ b/src/axis/plot.rs
@@ -4,7 +4,7 @@ use std::fmt;
 // Only imported for documentation. If you notice that this is no longer the
 // case, please change it.
 #[allow(unused_imports)]
-use crate::Picture;
+use crate::{Axis, Picture};
 
 /// Coordinates inside a plot.
 pub mod coordinate;

--- a/src/axis/plot.rs
+++ b/src/axis/plot.rs
@@ -65,7 +65,9 @@ impl fmt::Display for PlotKey {
 /// # Examples
 ///
 /// ```no_run
-/// use pgfplots::axis::plot::Plot2D;
+/// # use pgfplots::ShowPdfError;
+/// # fn main() -> Result<(), ShowPdfError> {
+/// use pgfplots::{axis::plot::Plot2D, Engine, Picture};
 ///
 /// let mut plot = Plot2D::new();
 /// plot.coordinates = (-100..100)
@@ -73,8 +75,9 @@ impl fmt::Display for PlotKey {
 ///     .map(|i| (f64::from(i), f64::from(i*i)).into())
 ///     .collect();
 ///
-/// # #[cfg(feature = "tectonic")]
-/// plot.show();
+/// Picture::from(plot).show_pdf(Engine::PdfLatex)?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct Plot2D {
@@ -114,7 +117,7 @@ impl Plot2D {
     /// ```
     /// use pgfplots::axis::plot::Plot2D;
     ///
-    /// let mut plot = Plot2D::new();
+    /// let plot = Plot2D::new();
     /// ```
     pub fn new() -> Self {
         Default::default()

--- a/src/axis/plot/tests.rs
+++ b/src/axis/plot/tests.rs
@@ -313,24 +313,6 @@ fn plot_2d_add_key() {
 }
 
 #[test]
-fn plot_standalone_string() {
-    let plot = Plot2D::new();
-    assert_eq!(
-        "\\documentclass{standalone}
-\\usepackage{pgfplots}
-\\begin{document}
-\\begin{tikzpicture}
-\\begin{axis}
-\t\\addplot[] coordinates {
-\t};
-\\end{axis}
-\\end{tikzpicture}
-\\end{document}",
-        plot.standalone_string()
-    );
-}
-
-#[test]
 fn plot_2d_to_string() {
     let mut plot = Plot2D::new();
     assert_eq!(plot.to_string(), "\t\\addplot[] coordinates {\n\t};");

--- a/src/axis/tests.rs
+++ b/src/axis/tests.rs
@@ -159,22 +159,6 @@ fn axis_add_key() {
 }
 
 #[test]
-fn axis_standalone_string() {
-    let axis = Axis::new();
-    assert_eq!(
-        r#"\documentclass{standalone}
-\usepackage{pgfplots}
-\begin{document}
-\begin{tikzpicture}
-\begin{axis}
-\end{axis}
-\end{tikzpicture}
-\end{document}"#,
-        axis.standalone_string()
-    );
-}
-
-#[test]
 fn axis_to_string() {
     let mut axis = Axis::new();
     assert_eq!(axis.to_string(), "\\begin{axis}\n\\end{axis}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,60 +43,8 @@ use crate::axis::{
 use crate::axis::Axis;
 use std::fmt;
 
-#[cfg(feature = "inclusive")]
-use std::io::Write;
-
 /// Axis environment inside a [`Picture`].
 pub mod axis;
-
-/// The error type returned when showing a figure fails.
-#[cfg(feature = "inclusive")]
-#[derive(Clone, Copy, Debug)]
-pub enum ShowPdfError {
-    /// Compilation of LaTeX source failed internally
-    Compile,
-    /// Creating or writing to temporary file failed
-    Write,
-    /// Persisting the temporary file failed
-    Persist,
-    /// Opening the file failed
-    Open,
-}
-#[cfg(feature = "inclusive")]
-impl fmt::Display for ShowPdfError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            ShowPdfError::Compile => write!(f, "tectonic compilation error"),
-            ShowPdfError::Write => write!(f, "creating or writing to temporary file failed"),
-            ShowPdfError::Persist => write!(f, "persisting temporary file failed"),
-            ShowPdfError::Open => write!(f, "opening file error"),
-        }
-    }
-}
-#[cfg(feature = "inclusive")]
-impl From<tectonic::errors::Error> for ShowPdfError {
-    fn from(_: tectonic::errors::Error) -> Self {
-        Self::Compile
-    }
-}
-#[cfg(feature = "inclusive")]
-impl From<std::io::Error> for ShowPdfError {
-    fn from(_: std::io::Error) -> Self {
-        Self::Write
-    }
-}
-#[cfg(feature = "inclusive")]
-impl From<tempfile::PersistError> for ShowPdfError {
-    fn from(_: tempfile::PersistError) -> Self {
-        Self::Persist
-    }
-}
-#[cfg(feature = "inclusive")]
-impl From<opener::OpenError> for ShowPdfError {
-    fn from(_: opener::OpenError) -> Self {
-        Self::Open
-    }
-}
 
 /// Ti*k*Z options passed to the [`Picture`] environment.
 ///
@@ -225,30 +173,6 @@ impl Picture {
             + "\\begin{document}\n"
             + &self.to_string()
             + "\n\\end{document}"
-    }
-    /// Show the picture as a standalone PDF. This will create a file in the
-    /// location returned by [`std::env::temp_dir()`] and open it with the
-    /// default PDF viewer in your system.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use pgfplots::Picture;
-    ///
-    /// let mut picture = Picture::new();
-    /// picture.show();
-    /// ```
-    #[cfg(feature = "inclusive")]
-    pub fn show(&self) -> Result<(), ShowPdfError> {
-        let pdf_data = tectonic::latex_to_pdf(self.standalone_string())?;
-
-        let mut file = tempfile::Builder::new().suffix(".pdf").tempfile()?;
-        file.write_all(&pdf_data)?;
-        let (_file, path) = file.keep()?;
-
-        opener::open(&path)?;
-
-        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! A Rust library to generate publication-quality figures.
 //!
 //! This crate is a PGFPlots code generator, and provides utilities to create,
-//! customize, and compile high-quality plots. The `inclusive` feature allows
+//! customize, and compile high-quality plots. The `tectonic` feature allows
 //! users to fully process figures without relying on any externally installed
 //! software.
 //!
@@ -24,7 +24,7 @@
 //!     .map(|i| (f64::from(i), f64::from(i*i)).into())
 //!     .collect();
 //!
-//! # #[cfg(feature = "inclusive")]
+//! # #[cfg(feature = "tectonic")]
 //! plot.show();
 //! ```
 //!
@@ -55,7 +55,7 @@ pub mod axis;
 pub enum Engine {
     /// `Pdflatex` engine (requires `pdflatex` to be installed).
     PdfLatex,
-    #[cfg(feature = "inclusive")]
+    #[cfg(feature = "tectonic")]
     /// `Tectonic` engine (does not require any external software).
     Tectonic,
 }
@@ -69,7 +69,7 @@ pub enum CompileError {
     /// Compilation was executed but returned a non-zero exit code.
     #[error("compilation failed with status {status}")]
     BadExitCode { status: ExitStatus },
-    #[cfg(feature = "inclusive")]
+    #[cfg(feature = "tectonic")]
     /// Tectonic error.
     #[error("tectonic error")]
     TectonicError(#[from] tectonic::errors::Error),
@@ -278,7 +278,7 @@ impl Picture {
                     return Err(CompileError::BadExitCode { status });
                 }
             }
-            #[cfg(feature = "inclusive")]
+            #[cfg(feature = "tectonic")]
             // Modified from `tectonic::latex_to_pdf` to generate the files
             // instead of just returning the bytes.
             Engine::Tectonic => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,9 @@
 //! [`Plot2D`]. Plotting a quadratic function is as simple as:
 //!
 //! ```no_run
-//! use pgfplots::axis::plot::Plot2D;
+//! # use pgfplots::ShowPdfError;
+//! # fn main() -> Result<(), ShowPdfError> {
+//! use pgfplots::{axis::plot::Plot2D, Engine, Picture};
 //!
 //! let mut plot = Plot2D::new();
 //! plot.coordinates = (-100..100)
@@ -24,8 +26,14 @@
 //!     .map(|i| (f64::from(i), f64::from(i*i)).into())
 //!     .collect();
 //!
-//! # #[cfg(feature = "tectonic")]
-//! plot.show();
+//! // The `Engine::PdfLatex` variant requires a working LaTeX installation with
+//! // the `pgfplots` package installed.
+//! // The `Engine::Tectonic` variant (enabled by the `tectonic` feature) allows
+//! // users to fully process figures without relying on any externally
+//! // installed software.
+//! Picture::from(plot).show_pdf(Engine::PdfLatex)?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! It is possible to show multiple plots in the same axis environment by
@@ -117,9 +125,6 @@ impl fmt::Display for PictureKey {
 ///     % axis environments
 /// \end{tikzpicture}
 /// ```
-///
-/// You will rarely interact with a [`Picture`]. It is only useful to generate
-/// complex layouts with multiple axis environments.
 #[derive(Clone, Debug, Default)]
 pub struct Picture {
     keys: Vec<PictureKey>,
@@ -171,7 +176,7 @@ impl Picture {
     /// ```
     /// use pgfplots::Picture;
     ///
-    /// let mut picture = Picture::new();
+    /// let picture = Picture::new();
     /// ```
     pub fn new() -> Self {
         Default::default()
@@ -210,7 +215,7 @@ impl Picture {
     /// ```
     /// use pgfplots::Picture;
     ///
-    /// let mut picture = Picture::new();
+    /// let picture = Picture::new();
     /// assert_eq!(
     /// r#"\documentclass{standalone}
     /// \usepackage{pgfplots}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,12 +35,9 @@
 // Only imported for documentation. If you notice that this is no longer the
 // case, please change it.
 #[allow(unused_imports)]
-use crate::axis::{
-    plot::{Plot2D, PlotKey},
-    AxisKey,
-};
+use crate::axis::{plot::PlotKey, AxisKey};
 
-use crate::axis::Axis;
+use crate::axis::{plot::Plot2D, Axis};
 use rand::distributions::{Alphanumeric, DistString};
 use std::fmt;
 use std::io::Write;
@@ -153,6 +150,19 @@ impl fmt::Display for Picture {
     }
 }
 
+impl From<Axis> for Picture {
+    fn from(axis: Axis) -> Self {
+        Self {
+            keys: Vec::new(),
+            axes: vec![axis],
+        }
+    }
+}
+impl From<Plot2D> for Picture {
+    fn from(plot: Plot2D) -> Self {
+        Picture::from(Axis::from(plot))
+    }
+}
 impl Picture {
     /// Create a new, empty picture environment.
     ///


### PR DESCRIPTION
This pull request contains major changes to the public API:

- Error handling is now done properly using the `thiserror` crate.
- Simplified significantly the API to compile and visualize a figure without the `tectonic` feature.
- Rename the `inclusive` feature as `tectonic`.