### PR TITLE
Add marker plot key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["examples/*.png"]
 [dependencies]
 opener = "0.5"
 rand = "0.8"
+strum = { version = "0.24.1", features = ["derive"] }
 tectonic = { version = "0.12", optional = true }
 tempfile = "3"
 thiserror = "1"

--- a/src/axis/plot.rs
+++ b/src/axis/plot.rs
@@ -1,3 +1,6 @@
+use strum::Display;
+
+pub use crate::axis::plot::color::Color;
 use crate::axis::plot::coordinate::Coordinate2D;
 use std::fmt;
 
@@ -6,6 +9,8 @@ use std::fmt;
 #[allow(unused_imports)]
 use crate::{Axis, Picture};
 
+/// Universal color utility.
+pub mod color;
 /// Coordinates inside a plot.
 pub mod coordinate;
 
@@ -38,6 +43,8 @@ pub enum PlotKey {
     /// Note that error bars won't be drawn unless [`PlotKey::YError`] is also
     /// set.
     YErrorDirection(ErrorDirection),
+    /// Control the shape, color and size of markers.
+    Marker(Marker),
 }
 
 impl fmt::Display for PlotKey {
@@ -49,6 +56,7 @@ impl fmt::Display for PlotKey {
             PlotKey::XErrorDirection(value) => write!(f, "error bars/x dir={value}"),
             PlotKey::YError(value) => write!(f, "error bars/y {value}"),
             PlotKey::YErrorDirection(value) => write!(f, "error bars/y dir={value}"),
+            PlotKey::Marker(marker) => write!(f, "{marker}"),
         }
     }
 }
@@ -275,6 +283,127 @@ impl fmt::Display for ErrorDirection {
             ErrorDirection::Plus => write!(f, "plus"),
             ErrorDirection::Minus => write!(f, "minus"),
             ErrorDirection::Both => write!(f, "both"),
+        }
+    }
+}
+
+/// Control shape, size and color of markers.
+#[derive(Clone, Debug)]
+pub struct Marker {
+    shape: MarkShape,
+    options: Vec<MarkOption>,
+}
+
+impl Marker {
+    pub fn new(shape: MarkShape, options: Vec<MarkOption>) -> Self {
+        Self { shape, options }
+    }
+}
+
+impl fmt::Display for Marker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The text marker needs an additional flag:
+        let mark = if let MarkShape::Text(text) = &self.shape {
+            format!("mark=text, text mark={text}")
+        } else {
+            format!("mark={}", self.shape)
+        };
+        write!(
+            f,
+            "{mark}, mark options={{{}}}",
+            self.options
+                .iter()
+                .map(|option| option.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+/// Control the shape of markers.
+#[derive(Clone, Debug, Display)]
+#[strum(serialize_all = "lowercase")]
+pub enum MarkShape {
+    /// Set the marker to ⃝.
+    O,
+    /// Set the marker to ⏺.
+    #[strum(serialize = "*")]
+    OFilled,
+    /// Set the marker to ✕.
+    X,
+    /// Set the marker to +.
+    #[strum(serialize = "+")]
+    Plus,
+    /// Set the marker to −.
+    #[strum(serialize = "-")]
+    Minus,
+    /// Set the marker to |.
+    #[strum(serialize = "|")]
+    Pipe,
+    /// Set the marker to *.
+    Star,
+    /// Set the marker to ＊.
+    Asterisk,
+    /// Set the marker to ⊕.
+    OPlus,
+    /// Set the marker to ⊕. Same as `[Marker::OPlus]` but filled with a color.
+    #[strum(serialize = "oplus*")]
+    OPlusFilled,
+    /// Set the marker to ⊗.
+    OTimes,
+    /// Set the marker to ⊗. Same as `[Marker::OTimes]` but filled with a color.
+    #[strum(serialize = "otimes*")]
+    OTimesFilled,
+    /// Set the marker to □.
+    Square,
+    /// Set the marker to □. Same as `[Marker::Square]` but filled with a color.
+    #[strum(serialize = "square*")]
+    SquareFilled,
+    /// Set the marker to △.
+    Triangle,
+    /// Set the marker to △. Same as `[Marker::Triangle]` but filled with a color.
+    #[strum(serialize = "triangle*")]
+    TriangleFilled,
+    /// Set the marker to ♢.
+    Diamond,
+    /// Set the marker to ♢. Same as `[Marker::Diamond]` but filled with a color.
+    #[strum(serialize = "diamond*")]
+    DiamondFilled,
+    /// Set the marker to ⬠.
+    Pentagon,
+    /// Set the marker to ⬠. Same as `[Marker::Pentagon]` but filled with a color.
+    #[strum(serialize = "pentagon*")]
+    PentagonFilled,
+    /// Set the marker to specified text.
+    #[strum(disabled)]
+    Text(String),
+}
+
+/// Control the color and scaling of markers.
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub enum MarkOption {
+    /// Scale the size of the marker.
+    Scale(f32),
+    /// Color the body of the marker. Only filled shapes (e.g. `[MarkShape::OFilled]`)
+    /// support filling the body.
+    Fill(Color),
+    /// Color the edge of the marker.
+    Draw(Color),
+    /// Scale the size of the marker on the x-axis only.
+    XScale(f64),
+    /// Scale the size of the marker on the y-axis only.
+    YScale(f64),
+}
+
+impl fmt::Display for MarkOption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MarkOption::Scale(number) => write!(f, "scale={number}"),
+            MarkOption::Fill(color) => write!(f, "fill={{{color}}}"),
+            MarkOption::Draw(color) => write!(f, "draw={{{color}}}"),
+            MarkOption::XScale(number) => write!(f, "xscale={number}"),
+            MarkOption::YScale(number) => write!(f, "yscale={number}"),
         }
     }
 }

--- a/src/axis/plot/color.rs
+++ b/src/axis/plot/color.rs
@@ -1,0 +1,67 @@
+use core::fmt;
+
+#[derive(Clone, Copy, Debug, strum::Display)]
+#[strum(serialize_all = "lowercase")]
+pub enum PredefinedColor {
+    Red,
+    Green,
+    Blue,
+    Cyan,
+    Magenta,
+    Yellow,
+    Black,
+    Gray,
+    White,
+    DarkGray,
+    LightGray,
+    Brown,
+    Lime,
+    Olive,
+    Orange,
+    Pink,
+    Purple,
+    Teal,
+    Violet,
+}
+
+#[derive(Clone, Debug)]
+pub struct Color {
+    value: String,
+}
+
+impl Color {
+    pub fn from_mix<I, C>(weighted_colors: I) -> Self
+    where
+        C: Into<Self>,
+        I: IntoIterator<Item = (C, u8)>,
+    {
+        let mut result = vec![String::from("rgb,255:")];
+        for (color, weight) in weighted_colors.into_iter() {
+            let color: Color = color.into();
+
+            result.push(color.to_string());
+            result.push(String::from(","));
+            result.push(weight.to_string());
+            result.push(String::from(";"));
+        }
+        // Remove the last weight
+        result.pop();
+        Self {
+            value: result.join(""),
+        }
+    }
+}
+
+impl fmt::Display for Color {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl From<PredefinedColor> for Color {
+    fn from(value: PredefinedColor) -> Self {
+        Self {
+            value: value.to_string(),
+        }
+    }
+}

--- a/src/axis/plot/tests.rs
+++ b/src/axis/plot/tests.rs
@@ -1,3 +1,5 @@
+use crate::axis::plot::color::PredefinedColor;
+
 use super::*;
 
 #[test]
@@ -132,6 +134,7 @@ fn plot_keys_tested() {
         PlotKey::XErrorDirection(_) => (),
         PlotKey::YError(_) => (),
         PlotKey::YErrorDirection(_) => (),
+        PlotKey::Marker(..) => (),
     }
 }
 
@@ -248,6 +251,188 @@ fn plot_key_y_error_direction_to_string() {
     assert_eq!(
         PlotKey::YErrorDirection(ErrorDirection::Both).to_string(),
         String::from("error bars/y dir=both")
+    );
+}
+
+#[test]
+fn plot_key_marker_to_string() {
+    assert_eq!(
+        PlotKey::Marker(Marker::new(MarkShape::O, vec![])).to_string(),
+        String::from("mark=o, mark options={}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::OFilled,
+            vec![MarkOption::Fill(PredefinedColor::Blue.into())]
+        ))
+        .to_string(),
+        String::from("mark=*, mark options={fill=blue}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(MarkShape::X, vec![MarkOption::Scale(1.5)])).to_string(),
+        String::from("mark=x, mark options={scale=1.5}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::Plus,
+            vec![MarkOption::Draw(PredefinedColor::Green.into())]
+        ))
+        .to_string(),
+        String::from("mark=+, mark options={draw=green}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::Minus,
+            vec![
+                MarkOption::Fill(PredefinedColor::Blue.into()),
+                MarkOption::Scale(2.0)
+            ]
+        ))
+        .to_string(),
+        String::from("mark=-, mark options={fill=blue, scale=2}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::Pipe,
+            vec![
+                MarkOption::Fill(PredefinedColor::Blue.into()),
+                MarkOption::Draw(PredefinedColor::Black.into())
+            ]
+        ))
+        .to_string(),
+        String::from("mark=|, mark options={fill=blue, draw=black}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::Star,
+            vec![
+                MarkOption::Draw(PredefinedColor::Blue.into()),
+                MarkOption::Fill(PredefinedColor::Black.into())
+            ]
+        ))
+        .to_string(),
+        String::from("mark=star, mark options={draw=blue, fill=black}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::OPlus,
+            vec![
+                MarkOption::Draw(PredefinedColor::Blue.into()),
+                MarkOption::Scale(1.5)
+            ]
+        ))
+        .to_string(),
+        String::from("mark=oplus, mark options={draw=blue, scale=1.5}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::OPlusFilled,
+            vec![
+                MarkOption::Scale(1.5),
+                MarkOption::Draw(PredefinedColor::Blue.into())
+            ]
+        ))
+        .to_string(),
+        String::from("mark=oplus*, mark options={scale=1.5, draw=blue}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::OTimes,
+            vec![
+                MarkOption::Scale(1.5),
+                MarkOption::Fill(PredefinedColor::Blue.into())
+            ]
+        ))
+        .to_string(),
+        String::from("mark=otimes, mark options={scale=1.5, fill=blue}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::OTimesFilled,
+            vec![
+                MarkOption::Draw(PredefinedColor::Blue.into()),
+                MarkOption::Fill(PredefinedColor::Yellow.into()),
+                MarkOption::Scale(1.5)
+            ]
+        ))
+        .to_string(),
+        String::from("mark=otimes*, mark options={draw=blue, fill=yellow, scale=1.5}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::Square,
+            vec![
+                MarkOption::Draw(PredefinedColor::Blue.into()),
+                MarkOption::Scale(1.5),
+                MarkOption::Fill(PredefinedColor::Yellow.into())
+            ]
+        ))
+        .to_string(),
+        String::from("mark=square, mark options={draw=blue, scale=1.5, fill=yellow}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::SquareFilled,
+            vec![
+                MarkOption::Scale(1.5),
+                MarkOption::Draw(PredefinedColor::Blue.into()),
+                MarkOption::Fill(PredefinedColor::Yellow.into())
+            ]
+        ))
+        .to_string(),
+        String::from("mark=square*, mark options={scale=1.5, draw=blue, fill=yellow}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::Triangle,
+            vec![
+                MarkOption::Scale(1.5),
+                MarkOption::Fill(PredefinedColor::Yellow.into()),
+                MarkOption::Draw(PredefinedColor::Blue.into())
+            ]
+        ))
+        .to_string(),
+        String::from("mark=triangle, mark options={scale=1.5, fill=yellow, draw=blue}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::TriangleFilled,
+            vec![
+                MarkOption::Fill(PredefinedColor::Yellow.into()),
+                MarkOption::Scale(1.5),
+                MarkOption::Draw(PredefinedColor::Blue.into())
+            ]
+        ))
+        .to_string(),
+        String::from("mark=triangle*, mark options={fill=yellow, scale=1.5, draw=blue}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(
+            MarkShape::Diamond,
+            vec![
+                MarkOption::Fill(PredefinedColor::Yellow.into()),
+                MarkOption::Draw(PredefinedColor::Blue.into()),
+                MarkOption::Scale(1.5)
+            ]
+        ))
+        .to_string(),
+        String::from("mark=diamond, mark options={fill=yellow, draw=blue, scale=1.5}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(MarkShape::DiamondFilled, vec![])).to_string(),
+        String::from("mark=diamond*, mark options={}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(MarkShape::Pentagon, vec![])).to_string(),
+        String::from("mark=pentagon, mark options={}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(MarkShape::PentagonFilled, vec![])).to_string(),
+        String::from("mark=pentagon*, mark options={}")
+    );
+    assert_eq!(
+        PlotKey::Marker(Marker::new(MarkShape::Text(String::from("p")), vec![])).to_string(),
+        String::from("mark=text, text mark=p, mark options={}")
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ impl Picture {
         }
 
         let jobname = random_jobname();
-        let pdf_path = self.to_pdf(std::env::temp_dir(), &jobname, engine)?;
+        let pdf_path = self.to_pdf(std::env::temp_dir(), jobname, engine)?;
         opener::open(pdf_path)?;
         Ok(())
     }


### PR DESCRIPTION
Hey! First things first, I really enjoyed working with this crate! Thanks for your effort.

This PR adds another `PlotKey`, namely the `mark=...` key. I had the following problem:
I wanted to add multiple plots to one graph, but by default all points of the plots had the same symbol: 

![image](https://github.com/DJDuque/pgfplots/assets/70777530/f335878d-d083-4a4b-b4ee-04cd705cabda)

While I was able to use your `PlotKey::Custom(...)` to achieve my desired output below, I quickly found myself adding an own enum for this and thought that your crate would benefit of it as well.

Desired output:

![image](https://github.com/DJDuque/pgfplots/assets/70777530/3fd17a80-bcc2-41c8-b06b-9140ba1bb1a4)

Additionally I added `MarkerOption` to set the `mark options=...` key. This way we can control the color and the scaling of a marker:

![image](https://github.com/DJDuque/pgfplots/assets/70777530/20cd6e5a-f584-4360-9ba2-19228a512851)

What do you think about adding this to your crate? If you approve I'm happy to add this to your documentation! :) 